### PR TITLE
Resolve a `ResourceWarning` in the test suite on Python 3.13

### DIFF
--- a/changelog.d/20240605_103330_kurtmckee_address_resourcewarnings.rst
+++ b/changelog.d/20240605_103330_kurtmckee_address_resourcewarnings.rst
@@ -1,0 +1,4 @@
+Development
+-----------
+
+*   Resolve a ``ResourceWarning`` in the test suite on Python 3.13.

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -6,5 +6,7 @@ import sqliteimport
 def test_load(monkeypatch):
     meta_path = []
     monkeypatch.setattr("sys.meta_path", meta_path)
-    sqliteimport.load(sqlite3.connect(":memory:"))
+    connection = sqlite3.connect(":memory:")
+    sqliteimport.load(connection)
+    connection.close()
     assert len(meta_path) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ wheel_build_env = build_wheel
 depends =
     py{3.13, 3.12, 3.11, 3.10, 3.9, 3.8}: coverage-erase
 deps = -rrequirements/test/requirements.txt
+setenv =
+    PYTHONWARNINGS=all
+    PYTHONTRACEMALLOC=1
 commands = coverage run -m pytest
 
 [testenv:coverage-erase]


### PR DESCRIPTION
Development
-----------

*   Resolve a ``ResourceWarning`` in the test suite on Python 3.13.
