### PR TITLE
Fix a bug that allowed non-Python files to be importable

### DIFF
--- a/changelog.d/20241027_173835_kurtmckee_fix_fullnames.rst
+++ b/changelog.d/20241027_173835_kurtmckee_fix_fullnames.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+*   Fix a bug in the bundling code that allowed non-Python files to be importable.
+
+    Previously, a package containing a PEP 561 ``py.typed`` file
+    would have an importable submodule named ``{package}.py``.

--- a/src/sqliteimport/cli.py
+++ b/src/sqliteimport/cli.py
@@ -74,7 +74,12 @@ def bundle(directory: pathlib.Path, database: pathlib.Path) -> None:
         print(f"{'* ' if is_package else '  '} {file}")
         if (directory / file).is_dir():
             continue
-        fullname = file.parent if file.name == "__init__.py" else file.with_suffix("")
+        if file.name == "__init__.py":
+            fullname = str(file.parent)
+        elif file.suffix == ".py":
+            fullname = str(file.with_suffix(""))
+        else:
+            fullname = ""
         is_package = file.name == "__init__.py"
         connection.execute(
             """
@@ -82,7 +87,7 @@ def bundle(directory: pathlib.Path, database: pathlib.Path) -> None:
             VALUES (?, ?, ?, ?);
             """,
             (
-                str(fullname).replace("/", ".").replace("\\", "."),
+                fullname.replace("/", ".").replace("\\", "."),
                 str(file),
                 is_package,
                 (directory / file).read_text(),


### PR DESCRIPTION
Fixed
-----

*   Fix a bug in the bundling code that allowed non-Python files to be importable.

    Previously, a package containing a PEP 561 ``py.typed`` file
    would have an importable submodule named ``{package}.py``.
