### PR TITLE
Maintain banner in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
     SPDX-License-Identifier: MIT
 
 
-..  image:: docs/_static/banner.png
+..  image:: https://raw.githubusercontent.com/kurtmckee/sqliteimport/dfd7095f2df8d6e9249889dd85f102027d1a6cfb/docs/_static/banner.png
     :alt: sqlite import: Import Python code in sqlite databases.
 
 -------------------------------------------------------------------------------

--- a/assets/validate-readme-banner-url.py
+++ b/assets/validate-readme-banner-url.py
@@ -1,0 +1,38 @@
+# This file is a part of sqliteimport <https://github.com/kurtmckee/sqliteimport>
+# Copyright 2024 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
+
+"""
+Validate that the banner image in the README points to its most recent update.
+
+This helps ensure that each release on PyPI renders the README in a predictable way.
+"""
+
+import subprocess
+import sys
+
+BANNER = "docs/_static/banner.png"
+GET_LATEST_BANNER_SHA = f"git rev-list --max-count=1 HEAD {BANNER}"
+
+try:
+    stdout = subprocess.check_output(GET_LATEST_BANNER_SHA.split())
+except subprocess.CalledProcessError:
+    print("There was an error getting the latest commit SHA that changed the banner")
+    sys.exit(1)
+
+try:
+    sha = stdout.strip().decode("utf-8")
+except UnicodeError:
+    print("There was an error decoding the 'git rev-parse' output")
+    sys.exit(1)
+
+with open("README.rst") as file:
+    readme = file.read()
+
+if f"{sha}/{BANNER}" not in readme:
+    print("The latest commit that changed the banner isn't in the README.")
+    print("Modify the README to include this image URL:")
+    print()
+    print(f"https://raw.githubusercontent.com/kurtmckee/sqliteimport/{sha}/{BANNER}")
+    print()
+    sys.exit(1)

--- a/changelog.d/20241107_093906_kurtmckee_maintain_banner_in_readme.rst
+++ b/changelog.d/20241107_093906_kurtmckee_maintain_banner_in_readme.rst
@@ -1,0 +1,6 @@
+Documentation
+-------------
+
+*   Use an absolute URL to the banner in the README.
+
+    This helps ensure that PyPI releases will render the README consistently.

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}
     pypy{3.10}
     coverage-report
+    build
     mypy
     docs
 labels =
@@ -55,6 +56,18 @@ skip_install = true
 deps = -rrequirements/docs/requirements.txt
 commands =
     sphinx-build -aWEnqb html docs/ build/docs
+
+[testenv:build]
+base_python = py3.12
+skip_install = true
+deps =
+    build
+    twine
+    uv
+commands =
+    - python assets/validate-readme-banner-url.py
+    python -m build --installer uv --outdir dist/
+    twine check --strict dist/*
 
 [testenv:update]
 base_python = py3.13


### PR DESCRIPTION
Documentation
-------------

*   Use an absolute URL to the banner in the README.

    This helps ensure that PyPI releases will render the README consistently.
