### PR TITLE
Update the release prep workflow

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -25,7 +25,7 @@ jobs:
             pr-base: "releases"
             pr-title: "Release v$VERSION"
 
-    uses: "kurtmckee/github-workflows/.github/workflows/create-pr.yaml@60a96418270d905445669bc4a5e06936cb78001b" # v1.3
+    uses: "kurtmckee/github-workflows/.github/workflows/create-pr.yaml@ca26472ada33aa277527450aa46436f530e3d2c1" # v1.4
     with:
       config: "${{ toJSON(matrix) }}"
       version: "${{ inputs.version }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,13 @@ name: "🧪 Test"
 
 on:
   pull_request:
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # Release automation opens PRs as drafts without triggering CI;
+      # clicking "Ready for review" in the UI will trigger test runs.
+      - "ready_for_review"
   push:
     branches:
       - "main"
@@ -40,6 +47,6 @@ jobs:
             cache-paths:
               - ".mypy_cache/"
 
-    uses: "kurtmckee/github-workflows/.github/workflows/tox.yaml@2f156c58bf4ceebc623014b407f5711899e41235" # v1.0
+    uses: "kurtmckee/github-workflows/.github/workflows/tox.yaml@ca26472ada33aa277527450aa46436f530e3d2c1" # v1.4
     with:
       config: "${{ toJSON(matrix) }}"


### PR DESCRIPTION
Release PRs should now be opened in draft mode; clicking "Ready for review" should trigger CI.