### PR TITLE
Pin the build system requirement to `poetry-core` v2

### DIFF
--- a/changelog.d/20250206_080915_kurtmckee_update_build_system.rst
+++ b/changelog.d/20250206_080915_kurtmckee_update_build_system.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+*   Pin the build system requirement to ``poetry-core`` v2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Homepage = "https://github.com/kurtmckee/sqliteimport"
 sqliteimport = "sqliteimport.cli:group"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
Fixed
-----

*   Pin the build system requirement to ``poetry-core`` v2.
