### PR TITLE
Configure ReadtheDocs to use the `dirhtml` builder

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
   configuration: 'docs/conf.py'
+  builder: 'dirhtml'
   fail_on_warning: true
 
 python:

--- a/changelog.d/20250210_114254_kurtmckee_dirhtml.rst
+++ b/changelog.d/20250210_114254_kurtmckee_dirhtml.rst
@@ -1,0 +1,4 @@
+Documentation
+-------------
+
+*   Configure ReadtheDocs to use the ``dirhtml`` builder.


### PR DESCRIPTION
Documentation
-------------

*   Configure ReadtheDocs to use the ``dirhtml`` builder.
