### PR TITLE
Fix test project regeneration

### DIFF
--- a/changelog.d/20250211_091233_kurtmckee_poetry_2.rst
+++ b/changelog.d/20250211_091233_kurtmckee_poetry_2.rst
@@ -1,0 +1,8 @@
+Development
+-----------
+
+*   Fix test project regeneration, which broke when Poetry 2 was released.
+
+    *   Migrate from Poetry to ``build`` to build the test project wheels.
+    *   Pin the regeneration tool dependencies.
+    *   Update the test projects' ``pyproject.toml`` files to use PEP 621 metadata keys.

--- a/requirements/docs/poetry.toml
+++ b/requirements/docs/poetry.toml
@@ -1,2 +1,0 @@
-[warnings]
-export = false

--- a/requirements/mypy/poetry.toml
+++ b/requirements/mypy/poetry.toml
@@ -1,2 +1,0 @@
-[warnings]
-export = false

--- a/requirements/mypy/requirements.txt
+++ b/requirements/mypy/requirements.txt
@@ -1,4 +1,4 @@
 mypy-extensions==1.0.0 ; python_version >= "3.9"
-mypy==1.14.1 ; python_version >= "3.9"
+mypy==1.15.0 ; python_version >= "3.9"
 tomli==2.2.1 ; python_version >= "3.9" and python_version < "3.11"
 typing-extensions==4.12.2 ; python_version >= "3.9"

--- a/requirements/regenerate-test-projects/pyproject.toml
+++ b/requirements/regenerate-test-projects/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+build = "*"
+pip = "*"

--- a/requirements/regenerate-test-projects/requirements.txt
+++ b/requirements/regenerate-test-projects/requirements.txt
@@ -1,0 +1,8 @@
+build==1.2.2.post1 ; python_version >= "3.9"
+colorama==0.4.6 ; python_version >= "3.9" and os_name == "nt"
+importlib-metadata==8.6.1 ; python_version >= "3.9" and python_full_version < "3.10.2"
+packaging==24.2 ; python_version >= "3.9"
+pip==25.0.1 ; python_version >= "3.9"
+pyproject-hooks==1.2.0 ; python_version >= "3.9"
+tomli==2.2.1 ; python_version >= "3.9" and python_version < "3.11"
+zipp==3.21.0 ; python_version >= "3.9" and python_full_version < "3.10.2"

--- a/requirements/test/poetry.toml
+++ b/requirements/test/poetry.toml
@@ -1,2 +1,0 @@
-[warnings]
-export = false

--- a/requirements/test/requirements.txt
+++ b/requirements/test/requirements.txt
@@ -1,5 +1,5 @@
 colorama==0.4.6 ; python_version >= "3.9" and sys_platform == "win32"
-coverage==7.6.10 ; python_version >= "3.9"
+coverage==7.6.12 ; python_version >= "3.9"
 exceptiongroup==1.2.2 ; python_version >= "3.9" and python_version < "3.11"
 importlib-metadata==8.6.1 ; python_version >= "3.9" and python_version < "3.10"
 iniconfig==2.0.0 ; python_version >= "3.9"

--- a/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/METADATA
+++ b/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/METADATA
@@ -1,17 +1,13 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: module-filesystem
 Version: 1.1.1
 Summary: 
 License: MIT
 Author: Kurt McKee
 Author-email: contactme@kurtmckee.org
+Requires-Python: >=3.7
 Classifier: License :: OSI Approved :: MIT License
-Classifier: Programming Language :: Python :: 2
-Classifier: Programming Language :: Python :: 2.7
 Classifier: Programming Language :: Python :: 3
-Classifier: Programming Language :: Python :: 3.4
-Classifier: Programming Language :: Python :: 3.5
-Classifier: Programming Language :: Python :: 3.6
 Classifier: Programming Language :: Python :: 3.7
 Classifier: Programming Language :: Python :: 3.8
 Classifier: Programming Language :: Python :: 3.9

--- a/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/RECORD
+++ b/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/RECORD
@@ -1,7 +1,7 @@
 module_filesystem-1.1.1.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
-module_filesystem-1.1.1.dist-info/METADATA,sha256=q63m78qbu8_bgx_cRJQ2R3AN_YP3KN5IVzcsv5S7vgY,911
+module_filesystem-1.1.1.dist-info/METADATA,sha256=11i3mbOg9Ca50wDj-5ZuAxuY7MeeSmUP00QZ3PCeqCM,686
 module_filesystem-1.1.1.dist-info/RECORD,,
 module_filesystem-1.1.1.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
-module_filesystem-1.1.1.dist-info/WHEEL,sha256=iAMR_6Qh95yyjYIwRxyjpiFq4FhDPemrEV-SyWIQB3U,92
+module_filesystem-1.1.1.dist-info/WHEEL,sha256=IYZQI976HJqqOpQU6PHkJ8fb3tMNBFjg-Cn-pwAbaFM,88
 module_filesystem-1.1.1.dist-info/direct_url.json,,
 module_filesystem.py,sha256=bUu1TcGpMlFUpoB9EAQVyK4Mb-dhj5n5mNBaqYZrjfM,13

--- a/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/WHEEL
+++ b/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/WHEEL
@@ -1,4 +1,4 @@
 Wheel-Version: 1.0
-Generator: poetry-core 1.9.1
+Generator: poetry-core 2.0.1
 Root-Is-Purelib: true
-Tag: py2.py3-none-any
+Tag: py3-none-any

--- a/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/direct_url.json
+++ b/tests/installed-projects/filesystem/module_filesystem-1.1.1.dist-info/direct_url.json
@@ -1,1 +1,1 @@
-{"archive_info": {"hash": "sha256=a2ffda1c72d29cd9563a596a60723546ba61ec3c252195831c9b7c892e46110f", "hashes": {"sha256": "a2ffda1c72d29cd9563a596a60723546ba61ec3c252195831c9b7c892e46110f"}}, "url": "file:///module_filesystem-1.1.1-py2.py3-none-any.whl"}
+{"archive_info": {"hash": "sha256=641a24741f40489c27022592dcc46a01b853a8617918f9e40c07f2775222c6f0", "hashes": {"sha256": "641a24741f40489c27022592dcc46a01b853a8617918f9e40c07f2775222c6f0"}}, "url": "file:///module_filesystem-1.1.1-py3-none-any.whl"}

--- a/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/METADATA
+++ b/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/METADATA
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: package-resources-filesystem
 Version: 1.1.1
 Summary: 

--- a/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/RECORD
+++ b/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/RECORD
@@ -1,8 +1,8 @@
 package_resources_filesystem-1.1.1.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
-package_resources_filesystem-1.1.1.dist-info/METADATA,sha256=bRIR9byrlEeRogVJ__XF1rj8YwIg5ocgRLv0rpyAY7k,702
+package_resources_filesystem-1.1.1.dist-info/METADATA,sha256=Pin7IIWMNaKs5Zpho3xUaVzurEzCkK0AeL5F3Sxo1tw,702
 package_resources_filesystem-1.1.1.dist-info/RECORD,,
 package_resources_filesystem-1.1.1.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
-package_resources_filesystem-1.1.1.dist-info/WHEEL,sha256=Nq82e9rUAnEjt98J6MlVmMCZb-t9cYE2Ir1kpBmnWfs,88
+package_resources_filesystem-1.1.1.dist-info/WHEEL,sha256=IYZQI976HJqqOpQU6PHkJ8fb3tMNBFjg-Cn-pwAbaFM,88
 package_resources_filesystem-1.1.1.dist-info/direct_url.json,,
 package_resources_filesystem/__init__.py,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 package_resources_filesystem/resource.txt,sha256=UzUTwTl8uMzsBYUrUlFL7NX9jJwhUJ97wvXUYMYUPdg,9

--- a/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/WHEEL
+++ b/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/WHEEL
@@ -1,4 +1,4 @@
 Wheel-Version: 1.0
-Generator: poetry-core 1.9.1
+Generator: poetry-core 2.0.1
 Root-Is-Purelib: true
 Tag: py3-none-any

--- a/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/direct_url.json
+++ b/tests/installed-projects/filesystem/package_resources_filesystem-1.1.1.dist-info/direct_url.json
@@ -1,1 +1,1 @@
-{"archive_info": {"hash": "sha256=29858c6073d50a06dcab1ce39df0f36c0df5eea57d9d3ef28eb6fcd3a6192278", "hashes": {"sha256": "29858c6073d50a06dcab1ce39df0f36c0df5eea57d9d3ef28eb6fcd3a6192278"}}, "url": "file:///package_resources_filesystem-1.1.1-py3-none-any.whl"}
+{"archive_info": {"hash": "sha256=c78ee95bdfe08fd9317cf8f638dce75f955b730544b65c6bb9e07f3d62a35b03", "hashes": {"sha256": "c78ee95bdfe08fd9317cf8f638dce75f955b730544b65c6bb9e07f3d62a35b03"}}, "url": "file:///package_resources_filesystem-1.1.1-py3-none-any.whl"}

--- a/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/METADATA
+++ b/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/METADATA
@@ -1,17 +1,13 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: module-sqlite
 Version: 2.2.2
 Summary: 
 License: MIT
 Author: Kurt McKee
 Author-email: contactme@kurtmckee.org
+Requires-Python: >=3.7
 Classifier: License :: OSI Approved :: MIT License
-Classifier: Programming Language :: Python :: 2
-Classifier: Programming Language :: Python :: 2.7
 Classifier: Programming Language :: Python :: 3
-Classifier: Programming Language :: Python :: 3.4
-Classifier: Programming Language :: Python :: 3.5
-Classifier: Programming Language :: Python :: 3.6
 Classifier: Programming Language :: Python :: 3.7
 Classifier: Programming Language :: Python :: 3.8
 Classifier: Programming Language :: Python :: 3.9

--- a/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/RECORD
+++ b/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/RECORD
@@ -1,7 +1,7 @@
 module_sqlite-2.2.2.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
-module_sqlite-2.2.2.dist-info/METADATA,sha256=Fo-Tnd_dSLq4KSJQM0RuZo_SZYHdBk3Uob6oZrQ-fxc,907
+module_sqlite-2.2.2.dist-info/METADATA,sha256=ti4MsHvZ-Fx8mIoZMzYbEwnqA8kjWOoJt6w5yeVJGCI,682
 module_sqlite-2.2.2.dist-info/RECORD,,
 module_sqlite-2.2.2.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
-module_sqlite-2.2.2.dist-info/WHEEL,sha256=iAMR_6Qh95yyjYIwRxyjpiFq4FhDPemrEV-SyWIQB3U,92
+module_sqlite-2.2.2.dist-info/WHEEL,sha256=IYZQI976HJqqOpQU6PHkJ8fb3tMNBFjg-Cn-pwAbaFM,88
 module_sqlite-2.2.2.dist-info/direct_url.json,,
 module_sqlite.py,sha256=bUu1TcGpMlFUpoB9EAQVyK4Mb-dhj5n5mNBaqYZrjfM,13

--- a/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/WHEEL
+++ b/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/WHEEL
@@ -1,4 +1,4 @@
 Wheel-Version: 1.0
-Generator: poetry-core 1.9.1
+Generator: poetry-core 2.0.1
 Root-Is-Purelib: true
-Tag: py2.py3-none-any
+Tag: py3-none-any

--- a/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/direct_url.json
+++ b/tests/installed-projects/sqlite/module_sqlite-2.2.2.dist-info/direct_url.json
@@ -1,1 +1,1 @@
-{"archive_info": {"hash": "sha256=20b638c1c7902169760aaebbe6d1c0ed83ac2b36f894fe02eed3fd8580ae1ac5", "hashes": {"sha256": "20b638c1c7902169760aaebbe6d1c0ed83ac2b36f894fe02eed3fd8580ae1ac5"}}, "url": "file:///module_sqlite-2.2.2-py2.py3-none-any.whl"}
+{"archive_info": {"hash": "sha256=72818d7837cf85b2ebdfb7eccf98f19a6e93d96e664c50529cdb41aebe951f5e", "hashes": {"sha256": "72818d7837cf85b2ebdfb7eccf98f19a6e93d96e664c50529cdb41aebe951f5e"}}, "url": "file:///module_sqlite-2.2.2-py3-none-any.whl"}

--- a/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/METADATA
+++ b/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/METADATA
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: package-resources-sqlite
 Version: 2.2.2
 Summary: 

--- a/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/RECORD
+++ b/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/RECORD
@@ -1,8 +1,8 @@
 package_resources_sqlite-2.2.2.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
-package_resources_sqlite-2.2.2.dist-info/METADATA,sha256=sJmD_MkvHCoc0BAKdIAQoMgRVzumA4l0xOC7kqEO5RE,698
+package_resources_sqlite-2.2.2.dist-info/METADATA,sha256=Q87jZl652p5l-SE7heabkuCPUZ5k4OUPMvI9TSKD6VU,698
 package_resources_sqlite-2.2.2.dist-info/RECORD,,
 package_resources_sqlite-2.2.2.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
-package_resources_sqlite-2.2.2.dist-info/WHEEL,sha256=Nq82e9rUAnEjt98J6MlVmMCZb-t9cYE2Ir1kpBmnWfs,88
+package_resources_sqlite-2.2.2.dist-info/WHEEL,sha256=IYZQI976HJqqOpQU6PHkJ8fb3tMNBFjg-Cn-pwAbaFM,88
 package_resources_sqlite-2.2.2.dist-info/direct_url.json,,
 package_resources_sqlite/__init__.py,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 package_resources_sqlite/resource.txt,sha256=UzUTwTl8uMzsBYUrUlFL7NX9jJwhUJ97wvXUYMYUPdg,9

--- a/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/WHEEL
+++ b/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/WHEEL
@@ -1,4 +1,4 @@
 Wheel-Version: 1.0
-Generator: poetry-core 1.9.1
+Generator: poetry-core 2.0.1
 Root-Is-Purelib: true
 Tag: py3-none-any

--- a/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/direct_url.json
+++ b/tests/installed-projects/sqlite/package_resources_sqlite-2.2.2.dist-info/direct_url.json
@@ -1,1 +1,1 @@
-{"archive_info": {"hash": "sha256=eebf5eb000800954469f01c19ab705a38909685abfb3ec287a1b5e978505c612", "hashes": {"sha256": "eebf5eb000800954469f01c19ab705a38909685abfb3ec287a1b5e978505c612"}}, "url": "file:///package_resources_sqlite-2.2.2-py3-none-any.whl"}
+{"archive_info": {"hash": "sha256=31730908ca3ed3000088d21169fbba164ab738ea5261022cacd1d88847459401", "hashes": {"sha256": "31730908ca3ed3000088d21169fbba164ab738ea5261022cacd1d88847459401"}}, "url": "file:///package_resources_sqlite-2.2.2-py3-none-any.whl"}

--- a/tests/regenerate-test-projects.py
+++ b/tests/regenerate-test-projects.py
@@ -46,7 +46,7 @@ def wipe_directory(directory: pathlib.Path) -> None:
 def build_wheel(directory: pathlib.Path, output: pathlib.Path) -> None:
     """Build a wheel using Poetry."""
 
-    command = f"poetry build --format=wheel --directory={directory} --output={output}"
+    command = f"{sys.executable} -m build --outdir={output} {directory}"
     run_command(command.split())
 
 

--- a/tests/source-projects/package-resources/filesystem/pyproject.toml
+++ b/tests/source-projects/package-resources/filesystem/pyproject.toml
@@ -1,18 +1,14 @@
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-
-# poetry
-# ------
-
-[tool.poetry]
+[project]
 name = "package-resources-filesystem"
 version = "1.1.1"
 description = ""
-authors = ["Kurt McKee <contactme@kurtmckee.org>"]
+authors = [
+    { name = "Kurt McKee", email = "contactme@kurtmckee.org" },
+]
 license = "MIT"
 readme = "README.rst"
+requires-python = ">=3.7"
 
-[tool.poetry.dependencies]
-python = ">=3.7"
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/source-projects/package-resources/sqlite/pyproject.toml
+++ b/tests/source-projects/package-resources/sqlite/pyproject.toml
@@ -1,18 +1,14 @@
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-
-# poetry
-# ------
-
-[tool.poetry]
+[project]
 name = "package-resources-sqlite"
 version = "2.2.2"
 description = ""
-authors = ["Kurt McKee <contactme@kurtmckee.org>"]
+authors = [
+    { name = "Kurt McKee", email = "contactme@kurtmckee.org" },
+]
 license = "MIT"
 readme = "README.rst"
+requires-python = ">=3.7"
 
-[tool.poetry.dependencies]
-python = ">=3.7"
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/source-projects/single-file-module/filesystem/pyproject.toml
+++ b/tests/source-projects/single-file-module/filesystem/pyproject.toml
@@ -1,14 +1,14 @@
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-# poetry
-# ------
-
-[tool.poetry]
+[project]
 name = "module-filesystem"
 version = "1.1.1"
 description = ""
-authors = ["Kurt McKee <contactme@kurtmckee.org>"]
+authors = [
+    { name = "Kurt McKee", email = "contactme@kurtmckee.org" },
+]
 license = "MIT"
 readme = "README.rst"
+requires-python = ">=3.7"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/source-projects/single-file-module/sqlite/pyproject.toml
+++ b/tests/source-projects/single-file-module/sqlite/pyproject.toml
@@ -1,14 +1,14 @@
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-# poetry
-# ------
-
-[tool.poetry]
+[project]
 name = "module-sqlite"
 version = "2.2.2"
 description = ""
-authors = ["Kurt McKee <contactme@kurtmckee.org>"]
+authors = [
+    { name = "Kurt McKee", email = "contactme@kurtmckee.org" },
+]
 license = "MIT"
 readme = "README.rst"
+requires-python = ">=3.7"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,8 @@ commands =
     poetry export --directory="requirements/docs-integrations" --output="requirements.txt" --without-hashes
     poetry update --directory="requirements/mypy" --lock
     poetry export --directory="requirements/mypy" --output="requirements.txt" --without-hashes
+    poetry update --directory="requirements/regenerate-test-projects" --lock
+    poetry export --directory="requirements/regenerate-test-projects" --output="requirements.txt" --without-hashes
     poetry update --directory="requirements/test" --lock
     poetry export --directory="requirements/test" --output="requirements.txt" --without-hashes
 
@@ -126,9 +128,7 @@ base_python = py3.13
 description = Regenerate installed projects used by the test suite
 recreate = true
 skip_install = true
-deps =
-    pip
-    poetry
+deps = -r requirements/regenerate-test-projects/requirements.txt
 commands =
     python tests/regenerate-test-projects.py
 


### PR DESCRIPTION
Development
-----------

*   Fix test project regeneration, which broke when Poetry 2 was released.

    *   Migrate from Poetry to ``build`` to build the test project wheels.
    *   Pin the regeneration tool dependencies.
    *   Update the test projects' ``pyproject.toml`` files to use PEP 621 metadata keys.
