### PR TITLE
Add a script to log performance comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 poetry.lock
 *.sqlite3
 *.zip
+perf.*

--- a/assets/test-performance.sh
+++ b/assets/test-performance.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env sh
+
+set -eu
+
+rm -rf "build/perftest" || true
+rm perf.* || true
+python assets/generate-perftest-directory.py
+
+export PYTHONPROFILEIMPORTTIME=1
+export PYTHONDONTWRITEBYTECODE=1
+
+
+# Filesystem -- source only
+# -------------------------
+
+export FILE_PREFIX="perf.filesystem.source"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="build/perftest"
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+
+# Zip -- source only
+# ------------------
+
+export FILE_PREFIX="perf.zip.source.storeonly"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.zip"
+cd "build/perftest"
+zip -qr0 "../../${PYTHONPATH}" .
+cd "../.."
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+export FILE_PREFIX="perf.zip.source.fast"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.zip"
+cd "build/perftest"
+zip -qr1 "../../${PYTHONPATH}" .
+cd "../.."
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+export FILE_PREFIX="perf.zip.source.best"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.zip"
+cd "build/perftest"
+zip -qr9 "../../${PYTHONPATH}" .
+cd "../.."
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+
+# Sqlite
+# ------
+
+export FILE_PREFIX="perf.sqlite.source"
+export PYTHONPATH="${FILE_PREFIX}.sqlite3"
+PYTHONPROFILEIMPORTTIME="" sqliteimport bundle "build/perftest" "${PYTHONPATH}"
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import sqliteimport; import a' 2> "${FILE_PREFIX}.import.log"
+
+
+# Compile the source to bytecode
+# ------------------------------
+
+PYTHONPROFILEIMPORTTIME="" python -m compileall -q "build/perftest"
+
+
+# Filesystem -- bytecode
+# ----------------------
+
+export FILE_PREFIX="perf.filesystem.bytecode"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="build/perftest"
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+
+# Zip -- bytecode
+# ---------------
+
+export FILE_PREFIX="perf.zip.bytecode.storeonly"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.zip"
+cd "build/perftest"
+zip -qr0 "../../${PYTHONPATH}" .
+cd "../.."
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+export FILE_PREFIX="perf.zip.bytecode.fast"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.zip"
+cd "build/perftest"
+zip -qr1 "../../${PYTHONPATH}" .
+cd "../.."
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+export FILE_PREFIX="perf.zip.bytecode.best"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.zip"
+cd "build/perftest"
+zip -qr9 "../../${PYTHONPATH}" .
+cd "../.."
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+
+
+# Capture the file sizes
+# ----------------------
+
+ls -l perf.* > perf.files.log

--- a/changelog.d/20250212_123430_kurtmckee_perftest.rst
+++ b/changelog.d/20250212_123430_kurtmckee_perftest.rst
@@ -1,0 +1,6 @@
+Development
+-----------
+
+*   Add a script to log performance comparisons across multiple importers,
+    including source and bytecode files when imported from the filesystem,
+    from sqlite, and from zip files with varying compression levels.


### PR DESCRIPTION
Development
-----------

*   Add a script to log performance comparisons across multiple importers,
    including source and bytecode files when imported from the filesystem,
    from sqlite, and from zip files with varying compression levels.
