### PR TITLE
Add initial support for bundling and loading Python bytecode

### DIFF
--- a/assets/test-performance.sh
+++ b/assets/test-performance.sh
@@ -13,16 +13,18 @@ export PYTHONDONTWRITEBYTECODE=1
 # Filesystem -- source only
 # -------------------------
 
+echo
 export FILE_PREFIX="perf.filesystem.source"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="build/perftest"
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
 
 # Zip -- source only
 # ------------------
 
+echo
 export FILE_PREFIX="perf.zip.source.storeonly"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.zip"
@@ -30,8 +32,9 @@ cd "build/perftest"
 zip -qr0 "../../${PYTHONPATH}" .
 cd "../.."
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
+echo
 export FILE_PREFIX="perf.zip.source.fast"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.zip"
@@ -39,8 +42,9 @@ cd "build/perftest"
 zip -qr1 "../../${PYTHONPATH}" .
 cd "../.."
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
+echo
 export FILE_PREFIX="perf.zip.source.best"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.zip"
@@ -48,17 +52,19 @@ cd "build/perftest"
 zip -qr9 "../../${PYTHONPATH}" .
 cd "../.."
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
 
-# Sqlite
-# ------
+# Sqlite -- source only
+# ---------------------
 
+echo
 export FILE_PREFIX="perf.sqlite.source"
+echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.sqlite3"
-PYTHONPROFILEIMPORTTIME="" sqliteimport bundle "build/perftest" "${PYTHONPATH}"
+PYTHONPROFILEIMPORTTIME="" sqliteimport bundle "build/perftest" "${PYTHONPATH}" 1>/dev/null
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import sqliteimport; import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import sqliteimport; import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
 
 # Compile the source to bytecode
@@ -70,16 +76,18 @@ PYTHONPROFILEIMPORTTIME="" python -m compileall -q "build/perftest"
 # Filesystem -- bytecode
 # ----------------------
 
+echo
 export FILE_PREFIX="perf.filesystem.bytecode"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="build/perftest"
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
 
 # Zip -- bytecode
 # ---------------
 
+echo
 export FILE_PREFIX="perf.zip.bytecode.storeonly"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.zip"
@@ -87,8 +95,9 @@ cd "build/perftest"
 zip -qr0 "../../${PYTHONPATH}" .
 cd "../.."
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
+echo
 export FILE_PREFIX="perf.zip.bytecode.fast"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.zip"
@@ -96,8 +105,9 @@ cd "build/perftest"
 zip -qr1 "../../${PYTHONPATH}" .
 cd "../.."
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
+echo
 export FILE_PREFIX="perf.zip.bytecode.best"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.zip"
@@ -105,7 +115,19 @@ cd "build/perftest"
 zip -qr9 "../../${PYTHONPATH}" .
 cd "../.."
 command time --portability --output "${FILE_PREFIX}.time.log" \
-    python -c 'import a' 2> "${FILE_PREFIX}.import.log"
+    python -c 'import a; print(a)' 2> "${FILE_PREFIX}.import.log"
+
+
+# Sqlite -- bytecode
+# ------------------
+
+echo
+export FILE_PREFIX="perf.sqlite.bytecode"
+echo "${FILE_PREFIX}"
+export PYTHONPATH="${FILE_PREFIX}.sqlite3"
+PYTHONPROFILEIMPORTTIME="" sqliteimport bundle "build/perftest" "${PYTHONPATH}" 1>/dev/null
+command time --portability --output "${FILE_PREFIX}.time.log" \
+    python -c 'import sqliteimport; import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 
 
 # Capture the file sizes

--- a/changelog.d/20250215_093600_kurtmckee_bytecode.rst
+++ b/changelog.d/20250215_093600_kurtmckee_bytecode.rst
@@ -1,0 +1,9 @@
+Added
+-----
+
+*   Add initial support for bundling and loading Python bytecode (``.pyc`` files).
+
+    Performance testing on Linux shows that loading from sqlite is now twice as fast.
+
+    The implementation currently binds the sqlite database
+    to the Python version used to bundle it.

--- a/src/sqliteimport/accessor.py
+++ b/src/sqliteimport/accessor.py
@@ -64,6 +64,19 @@ class Accessor:
             ),
         )
 
+    def find_spec(self, fullname: str) -> tuple[bytes, bool] | None:
+        result: tuple[bytes, bool] | None = self.connection.execute(
+            """
+            SELECT
+                source,
+                is_package
+            FROM code
+            WHERE fullname = ?;
+            """,
+            (fullname,),
+        ).fetchone()
+        return result
+
     def get_file(self, path_like: str) -> bytes:
         source: bytes = self.connection.execute(
             """

--- a/src/sqliteimport/accessor.py
+++ b/src/sqliteimport/accessor.py
@@ -4,8 +4,12 @@
 
 from __future__ import annotations
 
+import importlib.util
+import marshal
 import pathlib
 import sqlite3
+import sys
+import types
 
 
 class Accessor:
@@ -44,12 +48,26 @@ class Accessor:
 
         fullname = ""
         is_package = False
+        contents = (directory / file).read_bytes()
 
+        # Source code
         if file.name == "__init__.py":
             is_package = True
+            # "x/y/__init__.py" -> "x/y"
             fullname = str(file.parent)
         elif file.suffix == ".py":
+            # "x/y/z.py" -> "x/y/z"
             fullname = str(file.with_suffix(""))
+
+        # Bytecode
+        elif file.name == f"__init__.{sys.implementation.cache_tag}.pyc":
+            is_package = True
+            # "x/y/__pycache__/__init__.cpython-xyz.pyc" -> "x/y"
+            fullname = str(file.parent.parent)
+        elif file.suffix == ".pyc":
+            suffix_length = sum(len(suffix) for suffix in file.suffixes)
+            # "x/y/__pycache__/z.cpython-xyz.pyc" -> "x/y/z"
+            fullname = str(file.parent.parent / file.name[:-suffix_length])
 
         self.connection.execute(
             """
@@ -60,21 +78,33 @@ class Accessor:
                 fullname.replace("/", ".").replace("\\", "."),
                 str(pathlib.PurePosixPath(file)),
                 is_package,
-                (directory / file).read_bytes(),
+                contents,
             ),
         )
 
-    def find_spec(self, fullname: str) -> tuple[bytes, bool] | None:
+    def find_spec(self, fullname: str) -> tuple[bytes | types.CodeType, bool] | None:
         result: tuple[bytes, bool] | None = self.connection.execute(
             """
             SELECT
                 source,
                 is_package
             FROM code
-            WHERE fullname = ?;
+            WHERE fullname = ?
+            ORDER BY
+                LENGTH(path) DESC
+            ;
             """,
             (fullname,),
         ).fetchone()
+        if result is None:
+            return None
+
+        # Byte code
+        code, is_package = result
+        if code.startswith(importlib.util.MAGIC_NUMBER):
+            return marshal.loads(code[16:], allow_code=True), is_package
+
+        # Source
         return result
 
     def get_file(self, path_like: str) -> bytes:

--- a/src/sqliteimport/bundler.py
+++ b/src/sqliteimport/bundler.py
@@ -12,8 +12,6 @@ def bundle(directory: pathlib.Path, accessor: sqliteimport.accessor.Accessor) ->
         rel_path = path.relative_to(directory)
         if rel_path.suffix in {".so"}:
             continue
-        if rel_path.name == "__pycache__":
-            continue
         if str(rel_path) == "bin":
             continue
         if path.is_dir():

--- a/src/sqliteimport/importer.py
+++ b/src/sqliteimport/importer.py
@@ -64,7 +64,7 @@ class SqliteFinder(importlib.abc.MetaPathFinder):
 
 
 class SqliteLoader(importlib.abc.Loader):
-    def __init__(self, code: bytes, accessor: Accessor) -> None:
+    def __init__(self, code: bytes | types.CodeType, accessor: Accessor) -> None:
         self.code = code
         self.accessor = accessor
 

--- a/src/sqliteimport/importer.py
+++ b/src/sqliteimport/importer.py
@@ -40,8 +40,7 @@ class SqliteFinder(importlib.abc.MetaPathFinder):
         path: typing.Sequence[str] | None,
         target: types.ModuleType | None = None,
     ) -> importlib.machinery.ModuleSpec | None:
-        query = "SELECT source, is_package FROM code WHERE fullname = ?;"
-        result = self.connection.execute(query, (fullname,)).fetchone()
+        result = self.accessor.find_spec(fullname)
         if result is None:
             return None
 
@@ -65,12 +64,12 @@ class SqliteFinder(importlib.abc.MetaPathFinder):
 
 
 class SqliteLoader(importlib.abc.Loader):
-    def __init__(self, source: str, accessor: Accessor) -> None:
-        self.source = source
+    def __init__(self, code: bytes, accessor: Accessor) -> None:
+        self.code = code
         self.accessor = accessor
 
     def exec_module(self, module: types.ModuleType) -> None:
-        exec(self.source, module.__dict__)
+        exec(self.code, module.__dict__)
 
     def get_resource_reader(self, fullname: str) -> SqliteTraversableResources:
         return SqliteTraversableResources(fullname, self.accessor)

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ labels =
 [testenv]
 package = wheel
 wheel_build_env = build_wheel
-
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
 depends =
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}, pypy{3.11, 3.10}: coverage-erase
 deps = -r requirements/test/requirements.txt


### PR DESCRIPTION
Added
-----

*   Add initial support for bundling and loading Python bytecode (``.pyc`` files).

    Performance testing on Linux shows that loading from sqlite is now twice as fast.

    The implementation currently binds the sqlite database
    to the Python version used to bundle it.
