### PR TITLE
Better bytecode

### DIFF
--- a/assets/generate-perftest-directory.py
+++ b/assets/generate-perftest-directory.py
@@ -1,3 +1,7 @@
+# This file is a part of sqliteimport <https://github.com/kurtmckee/sqliteimport>
+# Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
+
 # Generate a directory suitable for performance testing.
 
 import pathlib

--- a/assets/test-performance.ps1
+++ b/assets/test-performance.ps1
@@ -1,3 +1,7 @@
+# This file is a part of sqliteimport <https://github.com/kurtmckee/sqliteimport>
+# Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
+
 $env:PYTHONPROFILEIMPORTTIME=$null
 $env:PYTHONDONTWRITEBYTECODE=1
 
@@ -127,6 +131,7 @@ Write-Host "${env:FILE_PREFIX}"
 $env:PYTHONPATH="${env:FILE_PREFIX}.sqlite3"
 $env:PYTHONPROFILEIMPORTTIME=$null
 sqliteimport bundle "build\perftest" "${env:PYTHONPATH}" | Out-Null
+sqliteimport compile "${PYTHONPATH}"
 $env:PYTHONPROFILEIMPORTTIME=1
 Measure-Command {
     python -c 'import sqliteimport; import a; print(a)' 2> "${env:FILE_PREFIX}.import.log" | Write-Host

--- a/assets/test-performance.sh
+++ b/assets/test-performance.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# This file is a part of sqliteimport <https://github.com/kurtmckee/sqliteimport>
+# Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
 
 set -eu
 
@@ -126,6 +129,7 @@ export FILE_PREFIX="perf.sqlite.bytecode"
 echo "${FILE_PREFIX}"
 export PYTHONPATH="${FILE_PREFIX}.sqlite3"
 PYTHONPROFILEIMPORTTIME="" sqliteimport bundle "build/perftest" "${PYTHONPATH}" 1>/dev/null
+PYTHONPROFILEIMPORTTIME="" sqliteimport compile "${PYTHONPATH}"
 command time --portability --output "${FILE_PREFIX}.time.log" \
     python -c 'import sqliteimport; import a; print(a)' 2> "${FILE_PREFIX}.import.log"
 

--- a/changelog.d/20250217_174015_kurtmckee_better_bytecode.rst
+++ b/changelog.d/20250217_174015_kurtmckee_better_bytecode.rst
@@ -1,0 +1,12 @@
+Added
+-----
+
+*   Support compiling to, and loading from, pre-compiled bytecode in the database.
+
+    Performance testing on Linux shows that sqliteimport is now faster
+    than the filesystem when loading large dependency trees.
+
+*   Add a ``sqliteimport compile`` command to compile all Python source to bytecode.
+
+    The command should be run for each Python interpreter that will be used
+    by the application.

--- a/docs/bytecode.rst
+++ b/docs/bytecode.rst
@@ -1,0 +1,83 @@
+..
+    This file is a part of sqliteimport <https://github.com/kurtmckee/sqliteimport>
+    Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
+    SPDX-License-Identifier: MIT
+
+
+Bytecode support
+################
+
+Python is able to import pre-compiled bytecode much, much faster than source code,
+so sqliteimport supports pre-compiling and loading bytecode from databases.
+
+
+Compiling bytecode
+==================
+
+The ``sqliteimport compile`` command compiles the Python source code to bytecode.
+
+Because the bytecode format can change with each release of Python,
+sqliteimport uses the Python interpreter's magic number to lock the bytecode
+to the Python interpreter used to compile the bytecode.
+
+For this reason, if ``sqliteimport compile`` is only run using CPython 3.13,
+the bytecode in the database can only be used with CPython 3.13.
+Other CPython versions will continue to import source code.
+While reliable, it will be slow.
+Therefore, ``sqliteimport compile`` should be run using additional CPython interpreters
+that are supported by the application.
+
+Cross-compiling bytecode example
+--------------------------------
+
+For example, if an application supports multiple interpreter versions
+separate virtual environments could be created using different Python interpreters,
+resulting in optimized imports for each supported Python interpreter.
+
+The examples below show one possible way to accomplish this.
+
+..  code-block:: shell-session
+    :caption: Linux/macOS
+
+    $ python3.13 -m venv venv-313
+    $ venv-313/bin/pip install -r requirements.txt --target demo
+
+    $ venv-313/bin/pip install sqliteimport[cli]
+    $ venv-313/bin/sqliteimport bundle demo demo.sqlite3
+    $ venv-313/bin/sqliteimport compile demo.sqlite3
+
+    $ python3.12 -m venv venv-312
+    $ venv-312/bin/pip install sqliteimport[cli]
+    $ venv-312/bin/sqliteimport compile demo.sqlite3
+
+..  code-block:: pwsh-session
+    :caption: Windows (Powershell)
+
+    > "C:\Program Files\Python313\python.exe" -m venv venv-313
+    > venv-313\Scripts\pip install -r requirements.txt --target demo
+
+    > venv-313\Scripts\pip install sqliteimport[cli]
+    > venv-313\Scripts\sqliteimport bundle demo demo.sqlite3
+    > venv-313\Scripts\sqliteimport compile demo.sqlite3
+
+    > "C:\Program Files\Python312\python.exe" -m venv venv-312
+    > venv-312\Scripts\pip install sqliteimport[cli]
+    > venv-312\Scripts\sqliteimport compile demo.sqlite3
+
+
+..  seealso::
+
+    The CPython interpreter's source code contains `a list of magic numbers`_.
+
+
+Loading bytecode
+================
+
+sqliteimport will always automatically load bytecode if available.
+No additional configuration nor code is required.
+
+
+..  Links
+..  -----
+..
+.. _a list of magic numbers: https://github.com/python/cpython/blob/HEAD/Include/internal/pycore_magic_number.h

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,9 @@ Demo usage example, using ``demo.py`` in `the sqliteimport repository`_:
     # Generate a sqlite database containing the installed packages.
     sqliteimport bundle sample sample.sqlite3
 
+    # Compile the Python code in the sqlite database to bytecode.
+    sqliteimport compile sample.sqlite3
+
     # Demonstrate that importing from a database works.
     python demo.py sample.sqlite3
 
@@ -53,6 +56,7 @@ Table of contents
     :maxdepth: 1
 
     load
+    bytecode
     flake8/index
     isort/index
 

--- a/src/sqliteimport/accessor.py
+++ b/src/sqliteimport/accessor.py
@@ -43,6 +43,17 @@ class Accessor:
             """
         )
 
+    @staticmethod
+    def get_database_path(database: sqlite3.Connection) -> str:
+        """Get the path to the database, as reported by sqlite itself.
+
+        sqlite returns an empty string if the database is not associated with a file.
+        """
+
+        path: str
+        _, _, path = database.execute("PRAGMA database_list;").fetchone()
+        return path
+
     def add_file(self, directory: pathlib.Path, file: pathlib.Path) -> None:
         """Add a file to the database."""
 

--- a/src/sqliteimport/accessor.py
+++ b/src/sqliteimport/accessor.py
@@ -4,17 +4,36 @@
 
 from __future__ import annotations
 
-import importlib.util
 import marshal
 import pathlib
 import sqlite3
-import sys
 import types
+import typing
+
+from .util import get_magic_number, get_python_identifier
 
 
 class Accessor:
     def __init__(self, connection: sqlite3.Connection) -> None:
         self.connection = connection
+        self.find_spec_table = "code"
+        if (
+            "magic_numbers" in self.get_tables()
+            and get_magic_number() in self.get_magic_numbers()
+        ):
+            self.find_spec_table = self.get_bytecode_table_name(get_magic_number())
+
+    def get_tables(self) -> list[str]:
+        """List all the tables in the database."""
+
+        query = """
+            SELECT
+                name
+            FROM sqlite_master
+            WHERE type='table'
+            ;
+        """
+        return [row[0] for row in self.connection.execute(query).fetchall()]
 
     def initialize_database(self) -> None:
         """Create database tables and insert basic information about the database."""
@@ -36,10 +55,15 @@ class Accessor:
                 fullname text,
                 path text,
                 is_package boolean,
-                source text
+                contents text
             );
 
             CREATE INDEX fullname_index ON code (fullname);
+
+            CREATE TABLE magic_numbers (
+                magic_number INTEGER,
+                python_identifier TEXT
+            );
             """
         )
 
@@ -54,6 +78,21 @@ class Accessor:
         _, _, path = database.execute("PRAGMA database_list;").fetchone()
         return path
 
+    def get_magic_numbers(self) -> dict[int, str]:
+        """Get the magic numbers of the already-compiled bytecodes in the database."""
+
+        magic_numbers = self.connection.execute(
+            """
+            SELECT
+                magic_number,
+                python_identifier
+            FROM
+                magic_numbers
+            ;
+            """
+        ).fetchall()
+        return {row[0]: row[1] for row in magic_numbers}
+
     def add_file(self, directory: pathlib.Path, file: pathlib.Path) -> None:
         """Add a file to the database."""
 
@@ -61,7 +100,6 @@ class Accessor:
         is_package = False
         contents = (directory / file).read_bytes()
 
-        # Source code
         if file.name == "__init__.py":
             is_package = True
             # "x/y/__init__.py" -> "x/y"
@@ -70,19 +108,9 @@ class Accessor:
             # "x/y/z.py" -> "x/y/z"
             fullname = str(file.with_suffix(""))
 
-        # Bytecode
-        elif file.name == f"__init__.{sys.implementation.cache_tag}.pyc":
-            is_package = True
-            # "x/y/__pycache__/__init__.cpython-xyz.pyc" -> "x/y"
-            fullname = str(file.parent.parent)
-        elif file.suffix == ".pyc":
-            suffix_length = sum(len(suffix) for suffix in file.suffixes)
-            # "x/y/__pycache__/z.cpython-xyz.pyc" -> "x/y/z"
-            fullname = str(file.parent.parent / file.name[:-suffix_length])
-
         self.connection.execute(
             """
-            INSERT INTO code (fullname, path, is_package, source)
+            INSERT INTO code (fullname, path, is_package, contents)
             VALUES (?, ?, ?, ?);
             """,
             (
@@ -93,16 +121,72 @@ class Accessor:
             ),
         )
 
+    @staticmethod
+    def get_bytecode_table_name(magic_number: int) -> str:
+        """Generate a bytecode table name."""
+
+        return f"bytecode_{magic_number}"
+
+    def create_bytecode_table(self, magic_number: int) -> None:
+        """Create a compiled bytecode table."""
+
+        table_name = self.get_bytecode_table_name(magic_number)
+        self.connection.executescript(
+            f"""
+            CREATE TABLE {table_name}
+            (
+                fullname TEXT,
+                path TEXT,
+                is_package BOOLEAN,
+                contents TEXT
+            );
+
+            CREATE INDEX {table_name}_fullname_index ON {table_name} (fullname);
+            """
+        )
+
+    def add_bytecode(
+        self, magic_number: int, fullname: str, path: str, is_package: bool, code: bytes
+    ) -> None:
+        """Add compiled bytecode to the database for a given magic number."""
+
+        table_name = f"bytecode_{magic_number}"
+        self.connection.execute(
+            f"""
+            INSERT INTO {table_name} (fullname, path, is_package, contents)
+            VALUES (?, ?, ?, ?);
+            """,
+            (
+                fullname,
+                path,
+                is_package,
+                code,
+            ),
+        )
+
+    def mark_magic_number(self, magic_number: int) -> None:
+        """Mark that bytecode has been fully compiled for a given magic number."""
+
+        self.connection.execute(
+            """
+            INSERT INTO magic_numbers (magic_number, python_identifier)
+            VALUES ($magic_number, $python_identifier)
+            ;
+            """,
+            {
+                "magic_number": magic_number,
+                "python_identifier": get_python_identifier(),
+            },
+        )
+
     def find_spec(self, fullname: str) -> tuple[bytes | types.CodeType, bool] | None:
         result: tuple[bytes, bool] | None = self.connection.execute(
-            """
+            f"""
             SELECT
-                source,
+                contents,
                 is_package
-            FROM code
+            FROM {self.find_spec_table}
             WHERE fullname = ?
-            ORDER BY
-                LENGTH(path) DESC
             ;
             """,
             (fullname,),
@@ -110,25 +194,25 @@ class Accessor:
         if result is None:
             return None
 
+        # Source code
+        if self.find_spec_table == "code":
+            return result
+
         # Byte code
         code, is_package = result
-        if code.startswith(importlib.util.MAGIC_NUMBER):
-            return marshal.loads(code[16:], allow_code=True), is_package
-
-        # Source
-        return result
+        return marshal.loads(code, allow_code=True), is_package
 
     def get_file(self, path_like: str) -> bytes:
-        source: bytes = self.connection.execute(
+        contents: bytes = self.connection.execute(
             """
             SELECT
-                source
+                contents
             FROM code
             WHERE path LIKE ?;
             """,
             (path_like,),
         ).fetchone()[0]
-        return source
+        return contents
 
     def list_directory(self, path_like: str) -> list[str]:
         """List the contents of a directory."""
@@ -171,3 +255,19 @@ class Accessor:
             else:
                 parsed_results.append(result[0])
         return parsed_results
+
+    def iter_source_code(self) -> typing.Generator[tuple[str, str, bool, str]]:
+        cursor = self.connection.cursor()
+        iterable = cursor.execute(
+            """
+            SELECT
+                fullname,
+                path,
+                is_package,
+                contents
+            FROM code
+            WHERE path LIKE '%.py'
+            ;
+            """
+        )
+        yield from (row for row in iterable)

--- a/src/sqliteimport/bundler.py
+++ b/src/sqliteimport/bundler.py
@@ -1,9 +1,9 @@
 import pathlib
 
-import sqliteimport.accessor
+from .accessor import Accessor
 
 
-def bundle(directory: pathlib.Path, accessor: sqliteimport.accessor.Accessor) -> None:
+def bundle(directory: pathlib.Path, accessor: Accessor) -> None:
     """Bundle files in a directory into a database."""
 
     paths: list[pathlib.Path] = list(directory.glob("*"))
@@ -11,6 +11,8 @@ def bundle(directory: pathlib.Path, accessor: sqliteimport.accessor.Accessor) ->
     for path in paths:
         rel_path = path.relative_to(directory)
         if rel_path.suffix in {".so"}:
+            continue
+        if rel_path.name == "__pycache__":
             continue
         if str(rel_path) == "bin":
             continue

--- a/src/sqliteimport/cli.py
+++ b/src/sqliteimport/cli.py
@@ -3,8 +3,9 @@ import sqlite3
 import sys
 import textwrap
 
-from . import bundler
+from . import bundler, compiler
 from .accessor import Accessor
+from .util import get_magic_number
 
 try:
     import click
@@ -49,4 +50,40 @@ def bundle(directory: pathlib.Path, database: pathlib.Path) -> None:
         accessor.initialize_database()
 
         bundler.bundle(directory, accessor)
+        connection.commit()
+
+
+@group.command(name="compile", no_args_is_help=True)
+@click.argument(
+    "database", type=click.Path(dir_okay=False, file_okay=True, path_type=pathlib.Path)
+)
+def compile_(database: pathlib.Path) -> None:
+    """Compile the source code in an existing database into bytecode.
+
+    This results in a significant performance improvement.
+    Note, though, that the bytecode is highly sensitive to the Python interpreter
+    used to compile the code, so other Python interpreters will not benefit from this
+    unless the source code is compiled for other Python interpreters, too.
+
+    For example, if this command is run on Python 3.13,
+    but the application can run on other Python versions,
+    only Python 3.13 interpreters will benefit from the bytecode.
+
+    Therefore, this command should be run on all Python versions that are supported
+    by the application importing from the database.
+    """
+
+    with sqlite3.connect(database) as connection:
+        accessor = Accessor(connection)
+        existing_magic_numbers = accessor.get_magic_numbers()
+        if get_magic_number() in existing_magic_numbers:
+            identifier = existing_magic_numbers[get_magic_number()]
+            msg = [
+                "The source code in the database has already been compiled",
+                f"for magic number {get_magic_number()} ({identifier})",
+            ]
+            click.echo("\n".join(msg))
+            sys.exit(0)
+
+        compiler.compile_bytecode(accessor)
         connection.commit()

--- a/src/sqliteimport/compiler.py
+++ b/src/sqliteimport/compiler.py
@@ -1,0 +1,21 @@
+import marshal
+
+from .accessor import Accessor
+from .util import get_magic_number
+
+
+def compile_bytecode(accessor: Accessor) -> None:
+    """Compile source code already in the database."""
+
+    magic_number = get_magic_number()
+    if magic_number in accessor.get_magic_numbers():
+        return
+
+    accessor.create_bytecode_table(magic_number)
+    for row in accessor.iter_source_code():
+        fullname, path, is_package, source = row
+        code = compile(source, filename=path, mode="exec", dont_inherit=True)
+        bytecode = marshal.dumps(code, allow_code=True)
+        accessor.add_bytecode(magic_number, fullname, path, is_package, bytecode)
+
+    accessor.mark_magic_number(magic_number)

--- a/src/sqliteimport/importer.py
+++ b/src/sqliteimport/importer.py
@@ -29,8 +29,7 @@ class SqliteFinder(importlib.abc.MetaPathFinder):
             self.database = database
             self.connection = sqlite3.connect(database)
         else:  # isinstance(database, sqlite3.Connection)
-            _, _, path = database.execute("PRAGMA database_list;").fetchone()
-            self.database = pathlib.Path(path)
+            self.database = pathlib.Path(Accessor.get_database_path(database))
             self.connection = database
         self.accessor = Accessor(self.connection)
 

--- a/src/sqliteimport/importer.py
+++ b/src/sqliteimport/importer.py
@@ -20,7 +20,7 @@ if sys.version_info >= (3, 11):
 else:
     from importlib.abc import Traversable, TraversableResources
 
-from sqliteimport.accessor import Accessor
+from .accessor import Accessor
 
 
 class SqliteFinder(importlib.abc.MetaPathFinder):

--- a/src/sqliteimport/util.py
+++ b/src/sqliteimport/util.py
@@ -1,0 +1,31 @@
+# This file is a part of sqliteimport <https://github.com/kurtmckee/sqliteimport>
+# Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import sys
+
+
+def get_magic_number() -> int:
+    return int.from_bytes(importlib.util.MAGIC_NUMBER[:2], "little")
+
+
+def get_python_identifier() -> str:
+    known_names = {
+        "cpython": "CPython",
+        "pypy": "PyPy",
+    }
+    name = known_names.get(sys.implementation.name) or sys.implementation.name
+    version = ".".join(str(v) for v in sys.version_info[:3])
+    if sys.version_info[3] != "final":
+        version += "".join(str(v) for v in sys.version_info[3:])
+
+    identifier = f"{name} {version}"
+
+    if sys.implementation.name == "pypy":
+        pypy_version = ".".join(str(v) for v in sys.implementation.version[:3])
+        if sys.implementation.version[3] != "final":
+            pypy_version += "".join(str(v) for v in sys.implementation.version[3:])
+        identifier += f" [{pypy_version}]"
+
+    return identifier


### PR DESCRIPTION
Added
-----

*   Support compiling to, and loading from, pre-compiled bytecode in the database.

    Performance testing on Linux shows that sqliteimport is now faster
    than the filesystem when loading large dependency trees.

*   Add a ``sqliteimport compile`` command to compile all Python source to bytecode.

    The command should be run for each Python interpreter that will be used
    by the application.
