### PR TITLE
Ensure `__file__` exists (and possibly `__cached__`)

### DIFF
--- a/changelog.d/20250319_072450_kurtmckee_module_attributes.rst
+++ b/changelog.d/20250319_072450_kurtmckee_module_attributes.rst
@@ -1,0 +1,11 @@
+Fixed
+-----
+
+*   Ensure that modules have a ``__file__`` attribute,
+    and possibly a ``__cached__`` attribute.
+
+    The Python data model docs make it clear that these attributes aren't guaranteed,
+    but it is nevertheless common for authors to assume that ``__file__`` exists.
+
+    The string value may not be usable for a specific purpose,
+    but the attributes now exist with the correct type for increased compatibility.

--- a/src/sqliteimport/importer.py
+++ b/src/sqliteimport/importer.py
@@ -50,6 +50,12 @@ class SqliteFinder(importlib.abc.MetaPathFinder):
             origin=self.database.name,
             is_package=is_package,
         )
+        spec.has_location = True
+        if isinstance(source, types.CodeType):
+            spec.cached = self.database.name
+        else:
+            spec.cached = None
+
         return spec
 
     def find_distributions(


### PR DESCRIPTION
Fixed
-----

*   Ensure that modules have a ``__file__`` attribute,
    and possibly a ``__cached__`` attribute.

    The Python data model docs make it clear that these attributes aren't guaranteed,
    but it is nevertheless common for authors to assume that ``__file__`` exists.

    The string value may not be usable for a specific purpose,
    but the attributes now exist with the correct type for increased compatibility.
