### PR TITLE
Fix a crash that occurs when CLI extras are not installed

### DIFF
--- a/changelog.d/20250512_213437_kurtmckee_guard_non_cli_execution.rst
+++ b/changelog.d/20250512_213437_kurtmckee_guard_non_cli_execution.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+*   Fix a crash that occurs when CLI extras are not installed.
+
+    This restores the user-friendly warning message behavior
+    when ``[cli]`` extras are not installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ source = [
 
 [tool.coverage.report]
 skip_covered = true
-fail_under = 49
+fail_under = 60
 
 
 # isort
@@ -74,6 +74,7 @@ extend_skip_glob = [
     "docs/flake8/*",
     "docs/isort/*",
 ]
+
 
 # mypy
 # ----

--- a/src/sqliteimport/cli.py
+++ b/src/sqliteimport/cli.py
@@ -8,27 +8,25 @@ import sqlite3
 import sys
 import textwrap
 
-import prettytable
-
 from . import bundler, compiler
 from .accessor import Accessor
 from .util import get_magic_number
 
 try:
     import click
+    import prettytable
 except ImportError:
-    print(
-        textwrap.dedent(
-            """
-            sqliteimport is not installed with CLI support.
+    message = """
+        sqliteimport is not installed with CLI support.
 
-            This is typically resolved by adding '[cli]' to the end of the package name
-            when installing sqliteimport. For example:
+        This is typically resolved by adding '[cli]' to the end of the package name
+        when installing sqliteimport. Example commands that may resolve this:
 
-                python -m pip install sqliteimport[cli]
-            """
-        )
-    )
+        *   python -m pip install sqliteimport[cli]
+        *   pipx install sqliteimport[cli]
+    """
+
+    print(textwrap.dedent(message), file=sys.stderr)
     sys.exit(2)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def test_output_when_missing_cli_dependencies(capsys):
+    with pytest.raises(SystemExit):
+        import sqliteimport.cli  # noqa: F401  # imported by unused
+
+    _, stderr = capsys.readouterr()
+    assert "sqliteimport is not installed with CLI support" in stderr


### PR DESCRIPTION
Fixed
-----

*   Fix a crash that occurs when CLI extras are not installed.

    This restores the user-friendly warning message behavior
    when ``[cli]`` extras are not installed.
