### PR TITLE
Raise a `FileNotFoundError` subclass when a file isn't found

### DIFF
--- a/changelog.d/20250514_090513_kurtmckee_raise_file_not_found.rst
+++ b/changelog.d/20250514_090513_kurtmckee_raise_file_not_found.rst
@@ -1,0 +1,6 @@
+Changed
+-------
+
+*   A ``FileNotFoundError`` subclass is now raised when a file isn't found.
+
+    Previously, a ``TypeError`` was implicitly raised due to the structure of the code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ sqlite_cache = true
 # ------
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 addopts = "--color=yes"
 filterwarnings = [
     "error",

--- a/src/sqliteimport/errors.py
+++ b/src/sqliteimport/errors.py
@@ -1,0 +1,9 @@
+class SqliteImportError(Exception):
+    pass
+
+
+class FileNotFoundInDatabaseError(SqliteImportError, FileNotFoundError):
+    def __init__(self, filename: str, database_path: str) -> None:
+        super().__init__(
+            2, "File not found in database", filename, None, database_path or ":memory:"
+        )

--- a/src/sqliteimport/importer.py
+++ b/src/sqliteimport/importer.py
@@ -76,7 +76,7 @@ class SqliteFinder(importlib.abc.MetaPathFinder):
         # This try/except block is an inelegant conditional.
         try:
             self.accessor.get_file(path=f"{context.name}-%.dist-info/METADATA")
-        except TypeError:
+        except FileNotFoundError:
             return
 
         yield SqliteDistribution(context.name, self.connection)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import pathlib
 import sqlite3
 import sys
@@ -21,3 +22,21 @@ def database():
         sqliteimport.load(connection)
 
         yield connection
+
+
+@pytest.fixture(scope="session")
+def ignore_tempermental_deprecations():
+    # Between 3.11 and 3.12.9, Python would throw DeprecationWarning when calling
+    # `importlib.resources.read_text()` and `importlib.resources.read_bytes()`.
+    # These are caught, confirmed to match expectations, and wholly ignored.
+    ignore_tempermental_warnings = contextlib.nullcontext()
+    if (3, 11) < sys.version_info[:3] <= (3, 12, 9):
+        ignore_tempermental_warnings = pytest.warns(
+            DeprecationWarning,
+            match=(
+                r"(open_text|read_text|read_binary) is deprecated. "
+                r"Use files\(\) instead"
+            ),
+        )
+
+    return ignore_tempermental_warnings


### PR DESCRIPTION
Changed
-------

*   A ``FileNotFoundError`` subclass is now raised when a file isn't found.

    Previously, a ``TypeError`` was implicitly raised due to the structure of the code.
