### PR TITLE
Find all available distributions when no name is given

### DIFF
--- a/changelog.d/20250515_073520_kurtmckee_fix_find_distributions_lacking_a_name.rst
+++ b/changelog.d/20250515_073520_kurtmckee_fix_find_distributions_lacking_a_name.rst
@@ -1,0 +1,6 @@
+Fixed
+-----
+
+*   Find all available distributions when no name is given.
+
+    This allows tools like flake8 to auto-detect installed plugins.


### PR DESCRIPTION
Fixed
-----

*   Find all available distributions when no name is given.

    This allows tools like flake8 to auto-detect installed plugins.
