### PR TITLE
Drop support for PyPy 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,6 @@ jobs:
               - "3.13"
             cpython-beta: "3.14"
             pypys:
-              - "3.10"
               - "3.11"
             cache-key-hash-files:
               - "pyproject.toml"

--- a/changelog.d/20250707_083312_kurtmckee_pypy_3_11_only.rst
+++ b/changelog.d/20250707_083312_kurtmckee_pypy_3_11_only.rst
@@ -1,0 +1,4 @@
+Python support
+--------------
+
+*   Drop support for PyPy 3.10.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     coverage-erase
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}
-    pypy{3.11, 3.10}
+    pypy{3.11}
     coverage-report
     build
     mypy
@@ -18,7 +18,7 @@ wheel_build_env = build_wheel
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 depends =
-    py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}, pypy{3.11, 3.10}: coverage-erase
+    py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}, pypy{3.11}: coverage-erase
 deps = -r requirements/test/requirements.txt
 commands =
     coverage run -m pytest
@@ -33,7 +33,7 @@ commands =
 [testenv:coverage-report{,-ci}]
 depends =
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}
-    pypy{3.11, 3.10}
+    pypy{3.11}
 deps =
     coverage[toml]
 skip_install = true


### PR DESCRIPTION

Python support
--------------

*   Drop support for PyPy 3.10.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>