### PR TITLE
Import from source code if importing from byte code fails

### DIFF
--- a/changelog.d/20250724_060626_kurtmckee_support_empty_directories_in_bytecode.rst
+++ b/changelog.d/20250724_060626_kurtmckee_support_empty_directories_in_bytecode.rst
@@ -1,0 +1,8 @@
+Fixed
+-----
+
+*   Fall back to importing from source code if importing from byte code fails.
+
+    This resolves a problem importing Flask when byte-compiled,
+    due to its ``sansio`` subdirectory, which has no ``__init__.py`` file
+    and whose submodules currently fail to import from the byte code table.


### PR DESCRIPTION
Fixed
-----

*   Fall back to importing from source code if importing from byte code fails.

    This resolves a problem importing Flask when byte-compiled,
    due to its ``sansio`` subdirectory, which has no ``__init__.py`` file
    and is not marked as a subpackage.
