### PR TITLE
Lock the GitHub CI runners to known, predictable versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         runner:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
+          - "ubuntu-24.04"
+          - "macos-15"
+          - "windows-2025"
 
         # These values will be applied to all runners listed above.
         include:

--- a/changelog.d/20250904_124905_kurtmckee_lock_github_runners.rst
+++ b/changelog.d/20250904_124905_kurtmckee_lock_github_runners.rst
@@ -1,0 +1,4 @@
+Development
+-----------
+
+*   Lock the GitHub CI runners to known, predictable versions.


### PR DESCRIPTION
Development
-----------

*   Lock the GitHub CI runners to known, predictable versions.
