### PR TITLE
Improve how test suite dependencies are locked

### DIFF
--- a/changelog.d/20250925_075145_kurtmckee_improve_requirements_locking.rst
+++ b/changelog.d/20250925_075145_kurtmckee_improve_requirements_locking.rst
@@ -1,0 +1,5 @@
+Development
+-----------
+
+*   Lock the coverage dependencies used for generating HTML reports
+    to match the same version used to gather coverage statistics.

--- a/requirements/docs-integrations/pyproject.toml
+++ b/requirements/docs-integrations/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
 package-mode = false
 
-[tool.poetry.dependencies]
-python = ">=3.10"
-flake8 = "*"
-isort = "*"
-ruff = "*"
+[project]
+name = "dependencies"
+requires-python = ">=3.10"
+dependencies = [
+    "flake8",
+    "isort",
+    "ruff",
+]

--- a/requirements/docs/pyproject.toml
+++ b/requirements/docs/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.poetry]
 package-mode = false
 
-[tool.poetry.dependencies]
-python = ">=3.10"
-sphinx = "*"
+[project]
+name = "dependencies"
+requires-python = ">=3.10"
+dependencies = [
+    "sphinx",
+]

--- a/requirements/mypy/pyproject.toml
+++ b/requirements/mypy/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.poetry]
 package-mode = false
 
-[tool.poetry.dependencies]
-python = ">=3.10"
-mypy = "*"
+[project]
+name = "dependencies"
+requires-python = ">=3.10"
+dependencies = [
+    "mypy",
+]

--- a/requirements/regenerate-test-projects/pyproject.toml
+++ b/requirements/regenerate-test-projects/pyproject.toml
@@ -1,7 +1,10 @@
 [tool.poetry]
 package-mode = false
 
-[tool.poetry.dependencies]
-python = ">=3.10"
-build = "*"
-pip = "*"
+[project]
+name = "dependencies"
+requires-python = ">=3.10"
+dependencies = [
+    "build",
+    "pip",
+]

--- a/requirements/test/pyproject.toml
+++ b/requirements/test/pyproject.toml
@@ -1,8 +1,16 @@
 [tool.poetry]
 package-mode = false
 
-[tool.poetry.dependencies]
-python = ">=3.10"
-coverage = { version = "*", extras = ["toml"] }
-pytest = "*"
-pytest-randomly = "*"
+[project]
+name = "dependencies"
+requires-python = ">=3.10"
+dependencies = [
+    "coverage[toml]",
+    "pytest",
+    "pytest-randomly",
+]
+
+[dependency-groups]
+coverage = [
+    "coverage[toml]",
+]

--- a/requirements/test/requirements-coverage.txt
+++ b/requirements/test/requirements-coverage.txt
@@ -1,0 +1,2 @@
+coverage==7.10.7 ; python_version >= "3.10"
+tomli==2.2.1 ; python_version >= "3.10" and python_full_version <= "3.11.0a6"

--- a/requirements/test/requirements.txt
+++ b/requirements/test/requirements.txt
@@ -1,5 +1,5 @@
 colorama==0.4.6 ; python_version >= "3.10" and sys_platform == "win32"
-coverage==7.10.6 ; python_version >= "3.10"
+coverage==7.10.7 ; python_version >= "3.10"
 exceptiongroup==1.3.0 ; python_version == "3.10"
 iniconfig==2.1.0 ; python_version >= "3.10"
 packaging==25.0 ; python_version >= "3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,7 @@ commands =
     coverage run -m pytest
 
 [testenv:coverage-erase]
-deps =
-    coverage[toml]
+deps = -r requirements/test/requirements-coverage.txt
 skip_install = true
 commands =
     coverage erase
@@ -34,8 +33,7 @@ commands =
 depends =
     py{3.14, 3.13, 3.12, 3.11, 3.10}
     pypy{3.11}
-deps =
-    coverage[toml]
+deps = -r requirements/test/requirements-coverage.txt
 skip_install = true
 commands_pre =
     - coverage combine
@@ -132,6 +130,7 @@ commands =
     poetry export --directory="requirements/regenerate-test-projects" --output="requirements.txt" --without-hashes
     poetry update --directory="requirements/test" --lock
     poetry export --directory="requirements/test" --output="requirements.txt" --without-hashes
+    poetry export --directory="requirements/test" --output="requirements-coverage.txt" --without-hashes --only="coverage"
 
 [testenv:prep-release]
 description = Make the changes needed to create a new release PR


### PR DESCRIPTION
Development
-----------

*   Lock the coverage dependencies used for generating HTML reports
    to match the same version used to gather coverage statistics.
